### PR TITLE
Support macOS 11 and 12

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,7 @@ let rdkafkaExclude = [
 let package = Package(
     name: "swift-kafka-client",
     platforms: [
-        .macOS(.v13),
+        .macOS(.v11),
         .iOS(.v16),
         .watchOS(.v9),
         .tvOS(.v16),

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 The Swift Kafka Client library provides a convenient way to interact with [Apache Kafka](https://kafka.apache.org) by leveraging [Swift's new concurrency features](https://docs.swift.org/swift-book/LanguageGuide/Concurrency.html). This package wraps the native [`librdkafka`](https://github.com/confluentinc/librdkafka) library.
 
+# Jamf Fork of Swift Kafka Client
+
+This repository is a fork of the official Swift Kafka Client.  The only changes in this fork are to support macOS 11 and macOS 12; the official repository supports macOS 13+.
+
+As of 2024-04-22 the only required changes are to use a custom `MillisecondDuration` struct instead of the `Duration` type from the Swift Standard Library.  A few calls to `Task.sleep(for:)` that use `Duration` were changed to `Task.sleep(nanoseconds:)`.  All unit tests still pass with no changes.
+
 ## Adding Kafka as a Dependency
 
 To use the `Kafka` library in a SwiftPM project,

--- a/Sources/Kafka/Configuration/KafkaConfiguration+Metrics.swift
+++ b/Sources/Kafka/Configuration/KafkaConfiguration+Metrics.swift
@@ -31,7 +31,7 @@ extension KafkaConfiguration {
         }
 
         /// Update interval for statistics.
-        public var updateInterval: Duration?
+        public var updateInterval: MillisecondDuration?
 
         /// Number of operations (callbacks, events, etc) waiting in the queue.
         public var queuedOperation: Gauge?
@@ -93,7 +93,7 @@ extension KafkaConfiguration {
         }
 
         /// Update interval for statistics.
-        public var updateInterval: Duration?
+        public var updateInterval: MillisecondDuration?
 
         /// Number of operations (callbacks, events, etc) waiting in the queue.
         public var queuedOperation: Gauge?

--- a/Sources/Kafka/Configuration/KafkaConfiguration+Security.swift
+++ b/Sources/Kafka/Configuration/KafkaConfiguration+Security.swift
@@ -286,7 +286,7 @@ extension KafkaConfiguration {
                 }
 
                 /// (Lowest granularity is milliseconds)
-                public static func value(_ value: Duration) -> KeyRefreshAttempts {
+                public static func value(_ value: MillisecondDuration) -> KeyRefreshAttempts {
                     precondition(
                         value.canBeRepresentedAsMilliseconds,
                         "Lowest granularity is milliseconds"

--- a/Sources/Kafka/Configuration/KafkaConfiguration.swift
+++ b/Sources/Kafka/Configuration/KafkaConfiguration.swift
@@ -60,7 +60,7 @@ public enum KafkaConfiguration {
             }
 
             /// (Lowest granularity is milliseconds)
-            public static func interval(_ value: Duration) -> RefreshInterval {
+            public static func interval(_ value: MillisecondDuration) -> RefreshInterval {
                 precondition(
                     value.canBeRepresentedAsMilliseconds,
                     "Lowest granularity is milliseconds"
@@ -79,7 +79,7 @@ public enum KafkaConfiguration {
 
         /// When a topic loses its leader a new metadata request will be enqueued with this initial interval, exponentially increasing until the topic metadata has been refreshed. This is used to recover quickly from transitioning leader brokers.
         /// Default: `.milliseconds(250)`
-        public var refreshFastInterval: Duration = .milliseconds(250) {
+        public var refreshFastInterval: MillisecondDuration = .milliseconds(250) {
             didSet {
                 precondition(
                     self.refreshFastInterval.canBeRepresentedAsMilliseconds,
@@ -94,7 +94,7 @@ public enum KafkaConfiguration {
 
         /// Apache Kafka topic creation is asynchronous and it takes some time for a new topic to propagate throughout the cluster to all brokers. If a client requests topic metadata after manual topic creation but before the topic has been fully propagated to the broker the client is requesting metadata from, the topic will seem to be non-existent and the client will mark the topic as such, failing queued produced messages with ERR__UNKNOWN_TOPIC. This setting delays marking a topic as non-existent until the configured propagation max time has passed. The maximum propagation time is calculated from the time the topic is first referenced in the client, e.g., on `send()`.
         /// Default: `.milliseconds(30000)`
-        public var maximumPropagation: Duration = .milliseconds(30000) {
+        public var maximumPropagation: MillisecondDuration = .milliseconds(30000) {
             didSet {
                 precondition(
                     self.maximumPropagation.canBeRepresentedAsMilliseconds,
@@ -111,7 +111,7 @@ public enum KafkaConfiguration {
         /// Default timeout for network requests. Producer: ProduceRequests will use the lesser value of ``KafkaConfiguration/SocketOptions/timeout``
         /// and remaining ``KafkaTopicConfiguration/messageTimeout``for the first message in the batch.
         /// Default: `.milliseconds(60000)`
-        public var timeout: Duration = .milliseconds(60000) {
+        public var timeout: MillisecondDuration = .milliseconds(60000) {
             didSet {
                 precondition(
                     self.timeout.canBeRepresentedAsMilliseconds,
@@ -178,7 +178,7 @@ public enum KafkaConfiguration {
         /// Maximum time allowed for broker connection setup (TCP connection setup as well SSL and SASL handshake).
         /// If the connection to the broker is not fully functional after this the connection will be closed and retried.
         /// Default: `.milliseconds(30000)`
-        public var connectionSetupTimeout: Duration = .milliseconds(30000)
+        public var connectionSetupTimeout: MillisecondDuration = .milliseconds(30000)
 
         public init() {}
     }
@@ -188,7 +188,7 @@ public enum KafkaConfiguration {
         /// How long to cache the broker address resolving results.
         /// (Lowest granularity is milliseconds)
         /// Default: `.milliseconds(1000)`
-        public var addressTimeToLive: Duration = .milliseconds(1000) {
+        public var addressTimeToLive: MillisecondDuration = .milliseconds(1000) {
             didSet {
                 precondition(
                     self.addressTimeToLive.canBeRepresentedAsMilliseconds,
@@ -215,7 +215,7 @@ public enum KafkaConfiguration {
             }
 
             /// (Lowest granularity is milliseconds)
-            public static func backoff(_ value: Duration) -> Backoff {
+            public static func backoff(_ value: MillisecondDuration) -> Backoff {
                 precondition(
                     value.canBeRepresentedAsMilliseconds,
                     "Lowest granularity is milliseconds"
@@ -235,7 +235,7 @@ public enum KafkaConfiguration {
 
         /// The maximum time to wait before reconnecting to a broker after the connection has been closed.
         /// Default: `.milliseconds(10000)`
-        public var maximumBackoff: Duration = .milliseconds(10000) {
+        public var maximumBackoff: MillisecondDuration = .milliseconds(10000) {
             didSet {
                 precondition(
                     self.maximumBackoff.canBeRepresentedAsMilliseconds,

--- a/Sources/Kafka/Configuration/KafkaConsumerConfiguration.swift
+++ b/Sources/Kafka/Configuration/KafkaConsumerConfiguration.swift
@@ -21,7 +21,7 @@ public struct KafkaConsumerConfiguration {
     /// The time between two consecutive polls.
     /// Effectively controls the rate at which incoming events and messages are consumed.
     /// Default: `.milliseconds(100)`
-    public var pollInterval: Duration = .milliseconds(100)
+    public var pollInterval: MillisecondDuration = .milliseconds(100)
 
     /// A struct representing different back pressure strategies for consuming messages in ``KafkaConsumer``.
     public struct BackPressureStrategy: Sendable, Hashable {
@@ -106,7 +106,7 @@ public struct KafkaConsumerConfiguration {
         /// If no hearts are received by the broker for a group member within the session timeout, the broker will remove the consumer from the group and trigger a rebalance.
         /// (Lowest granularity is milliseconds)
         /// Default: `.milliseconds(45000)`
-        public var timeout: Duration = .milliseconds(45000) {
+        public var timeout: MillisecondDuration = .milliseconds(45000) {
             didSet {
                 precondition(
                     timeout.canBeRepresentedAsMilliseconds,
@@ -124,7 +124,7 @@ public struct KafkaConsumerConfiguration {
     /// Group session keepalive heartbeat interval.
     /// (Lowest granularity is milliseconds)
     /// Default: `.milliseconds(3000)`
-    public var heartbeatInterval: Duration = .milliseconds(3000) {
+    public var heartbeatInterval: MillisecondDuration = .milliseconds(3000) {
         didSet {
             precondition(
                 heartbeatInterval.canBeRepresentedAsMilliseconds,
@@ -141,7 +141,7 @@ public struct KafkaConsumerConfiguration {
     ///
     /// (Lowest granularity is milliseconds)
     /// Default: `.milliseconds(300_000)`
-    public var maximumPollInterval: Duration = .milliseconds(300_000) {
+    public var maximumPollInterval: MillisecondDuration = .milliseconds(300_000) {
         didSet {
             precondition(
                 maximumPollInterval.canBeRepresentedAsMilliseconds,
@@ -209,7 +209,7 @@ public struct KafkaConsumerConfiguration {
     /// Metadata cache max age.
     /// (Lowest granularity is milliseconds)
     /// Default: `.milliseconds(900_000)`
-    public var maximumMetadataAge: Duration = .milliseconds(900_000) {
+    public var maximumMetadataAge: MillisecondDuration = .milliseconds(900_000) {
         didSet {
             precondition(
                 maximumMetadataAge.canBeRepresentedAsMilliseconds,

--- a/Sources/Kafka/Configuration/KafkaProducerConfiguration.swift
+++ b/Sources/Kafka/Configuration/KafkaProducerConfiguration.swift
@@ -24,7 +24,7 @@ public struct KafkaProducerConfiguration {
     /// The time between two consecutive polls.
     /// Effectively controls the rate at which incoming events are consumed.
     /// Default: `.milliseconds(100)`
-    public var pollInterval: Duration = .milliseconds(100)
+    public var pollInterval: MillisecondDuration = .milliseconds(100)
 
     /// Maximum timeout for flushing outstanding produce requests when the ``KafkaProducer`` is shutting down.
     /// Default: `10000`
@@ -80,7 +80,7 @@ public struct KafkaProducerConfiguration {
         /// A higher value allows larger and more effective (less overhead, improved compression) batches of messages to accumulate at the expense of increased message delivery latency.
         /// (Lowest granularity is milliseconds)
         /// Default: `.milliseconds(5)`
-        public var maximumMessageQueueTime: Duration = .milliseconds(5) {
+        public var maximumMessageQueueTime: MillisecondDuration = .milliseconds(5) {
             didSet {
                 precondition(
                     self.maximumMessageQueueTime.canBeRepresentedAsMilliseconds,
@@ -132,7 +132,7 @@ public struct KafkaProducerConfiguration {
     /// Metadata cache max age.
     /// (Lowest granularity is milliseconds)
     /// Default: `.milliseconds(900_000)`
-    public var maximumMetadataAge: Duration = .milliseconds(900_000) {
+    public var maximumMetadataAge: MillisecondDuration = .milliseconds(900_000) {
         didSet {
             precondition(
                 self.maximumMetadataAge.canBeRepresentedAsMilliseconds,

--- a/Sources/Kafka/Configuration/KafkaTopicConfiguration.swift
+++ b/Sources/Kafka/Configuration/KafkaTopicConfiguration.swift
@@ -41,7 +41,7 @@ public struct KafkaTopicConfiguration {
     /// The ack timeout of the producer request. This value is only enforced by the broker and relies on ``requiredAcknowledgements`` being != 0.
     /// (Lowest granularity is milliseconds)
     /// Default: `.milliseconds(30000)`
-    public var requestTimeout: Duration = .milliseconds(30000) {
+    public var requestTimeout: MillisecondDuration = .milliseconds(30000) {
         didSet {
             precondition(
                 self.requestTimeout.canBeRepresentedAsMilliseconds,
@@ -59,7 +59,7 @@ public struct KafkaTopicConfiguration {
         }
 
         /// (Lowest granularity is milliseconds)
-        public static func timeout(_ value: Duration) -> MessageTimeout {
+        public static func timeout(_ value: MillisecondDuration) -> MessageTimeout {
             precondition(
                 value.canBeRepresentedAsMilliseconds,
                 "Lowest granularity is milliseconds"

--- a/Sources/Kafka/KafkaConsumer.swift
+++ b/Sources/Kafka/KafkaConsumer.swift
@@ -396,7 +396,7 @@ public final class KafkaConsumer: Sendable, Service {
                         break
                     }
                 }
-                try await Task.sleep(for: self.configuration.pollInterval)
+                try await Task.sleep(nanoseconds: self.configuration.pollInterval.nanoseconds)
             case .terminatePollLoop:
                 return
             }
@@ -428,7 +428,7 @@ public final class KafkaConsumer: Sendable, Service {
                 let messageResults = self.batchConsumerPoll(client: client)
                 if messageResults.isEmpty {
                     // Still no new messages, so sleep.
-                    try await Task.sleep(for: self.configuration.pollInterval)
+                    try await Task.sleep(nanoseconds: self.configuration.pollInterval.nanoseconds)
                 } else {
                     // New messages were produced to the partition that we previously finished reading.
                     let yieldResult = source.yield(contentsOf: messageResults)
@@ -442,7 +442,7 @@ public final class KafkaConsumer: Sendable, Service {
                     }
                 }
             case .suspendPollLoop:
-                try await Task.sleep(for: self.configuration.pollInterval)
+                try await Task.sleep(nanoseconds: self.configuration.pollInterval.nanoseconds)
             case .terminatePollLoop:
                 return
             }

--- a/Sources/Kafka/KafkaProducer.swift
+++ b/Sources/Kafka/KafkaProducer.swift
@@ -232,7 +232,7 @@ public final class KafkaProducer: Service, Sendable {
                         _ = source?.yield(.deliveryReports(reports))
                     }
                 }
-                try await Task.sleep(for: self.configuration.pollInterval)
+                try await Task.sleep(nanoseconds: self.configuration.pollInterval.nanoseconds)
             case .flushFinishSourceAndTerminatePollLoop(let client, let source):
                 precondition(
                     0...Int(Int32.max) ~= self.configuration.flushTimeoutMilliseconds,

--- a/Sources/Kafka/Utilities/Duration+Helpers.swift
+++ b/Sources/Kafka/Utilities/Duration+Helpers.swift
@@ -12,14 +12,23 @@
 //
 //===----------------------------------------------------------------------===//
 
-extension Duration {
-    internal var inMilliseconds: UInt {
-        let seconds = Double(components.seconds) * 1000.0
-        let attoseconds = Double(components.attoseconds) * 1e-15
-        return UInt(seconds + attoseconds)
+/// Simple type that can be used to express a duration in milliseconds
+///
+/// Apple's code uses the `Duration` type which is only available in macOS 13+.  Throughout the
+/// code, the minimum precision is milliseconds.
+///
+/// This type represents a duration in milliseconds using an `UInt` for storage.
+public struct MillisecondDuration: Sendable, Equatable, Hashable {
+    public var inMilliseconds: UInt
+
+    public static func milliseconds(_ value: UInt) -> Self {
+        MillisecondDuration(inMilliseconds: value)
     }
 
-    internal var canBeRepresentedAsMilliseconds: Bool {
-        return self.inMilliseconds > 0
+    internal let canBeRepresentedAsMilliseconds: Bool = true
+
+    /// This is here to support the backwards compatible `Task.sleep(nanoseconds:)` function
+    internal var nanoseconds: UInt64 {
+        UInt64(self.inMilliseconds * 1_000_000)
     }
 }


### PR DESCRIPTION
Convert code that uses `Duration` to use a custom type `MillisecondDuration` that handles the same things in the code.

Unit tests all still pass with no changes, and some of the unit tests exercise the timeouts and timing information affected by these code changes.